### PR TITLE
Node.cc segfault fix

### DIFF
--- a/html/Node.cc
+++ b/html/Node.cc
@@ -42,14 +42,14 @@ void Node::parseAttributes()
 	++ptr;
 
 	// Skip initial blankspace
-	while (isspace(*ptr)) ++ptr;
+	while (*ptr && isspace(*ptr)) ++ptr;
 
 	// Skip tagname
-	if (!isalpha(*ptr)) return;
-	while (!isspace(*ptr) && *ptr != '>') ++ptr;
+	if (!*ptr || !isalpha(*ptr)) return;
+	while (*ptr && !isspace(*ptr) && *ptr != '>') ++ptr;
 
 	// Skip blankspace after tagname
-	while (isspace(*ptr)) ++ptr;
+	while (*ptr && isspace(*ptr)) ++ptr;
 
 	while (*ptr && *ptr != '>') 
 	{


### PR DESCRIPTION
fixed a case where you can traverse unowned memory.  probably more cases of this, but this one in particular bit me.
